### PR TITLE
Usa el auth0.properties en el classpath

### DIFF
--- a/auth0_utils/.gitignore
+++ b/auth0_utils/.gitignore
@@ -1,0 +1,8 @@
+# git ignore file for auth0-utils
+
+/target/
+
+# eclipse
+.classpath
+.project
+.settings/

--- a/auth0_utils/pom.xml
+++ b/auth0_utils/pom.xml
@@ -1,39 +1,44 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <groupId>co.edu.uniandes.csw</groupId>
-    <artifactId>auth0-utils</artifactId>
-    <version>2.1</version>
-    <packaging>jar</packaging>
-    <dependencies>
-        <dependency>
-            <groupId>com.mashape.unirest</groupId>
-            <artifactId>unirest-java</artifactId>
-            <version>1.3.0</version>
-            <type>jar</type>
-        </dependency>
-        <dependency>
-            <groupId>io.jsonwebtoken</groupId>
-            <artifactId>jjwt</artifactId>
-            <version>0.7.0</version>
-            <type>jar</type>
-        </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>18.0</version>
-            <type>jar</type>
-        </dependency>
-        <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
-            <version>7.0</version>
-            <type>jar</type>
-        </dependency>
-    </dependencies>
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-    </properties>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	
+	<groupId>co.edu.uniandes.csw</groupId>
+	<artifactId>auth0-utils</artifactId>
+	<version>2.2</version>
+	<packaging>jar</packaging>
+	
+	<dependencies>
+		<dependency>
+			<groupId>com.mashape.unirest</groupId>
+			<artifactId>unirest-java</artifactId>
+			<version>1.3.0</version>
+			<type>jar</type>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt</artifactId>
+			<version>0.7.0</version>
+			<type>jar</type>
+		</dependency>
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+			<version>18.0</version>
+			<type>jar</type>
+		</dependency>
+		<dependency>
+			<groupId>javax</groupId>
+			<artifactId>javaee-api</artifactId>
+			<version>7.0</version>
+			<type>jar</type>
+		</dependency>
+	</dependencies>
+	
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<maven.compiler.source>1.8</maven.compiler.source>
+		<maven.compiler.target>1.8</maven.compiler.target>
+	</properties>
 </project>

--- a/auth0_utils/src/main/java/co/edu/uniandes/csw/auth/api/AuthenticationApi.java
+++ b/auth0_utils/src/main/java/co/edu/uniandes/csw/auth/api/AuthenticationApi.java
@@ -18,8 +18,6 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.SignatureException;
 import java.io.BufferedReader;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -57,26 +55,21 @@ public class AuthenticationApi {
     }
 
     private Properties prop = new Properties();
-    private InputStream input = null;
     private static LoadingCache<String, UserDTO> profileCache;
-    private static final String PATH = System.getenv("AUTH0_PROPERTIES");
     private Process process;
     public static String tmp_path;
     public static String access_token;
 
     public AuthenticationApi() throws IOException, UnirestException, JSONException, InterruptedException, ExecutionException {
 
-        try {
-            input = new FileInputStream(PATH);
-            try {
-                prop.load(input);
-            } catch (IOException ex) {
-                Logger.getLogger(AuthenticationApi.class.getName()).log(Level.SEVERE, null, ex);
-            }
-        } catch (FileNotFoundException ex) {
+    	// load the configuration from an "auth0.properties" file in the classpath
+    	try {
+        	prop.load(AuthenticationApi.class.getClassLoader().getResourceAsStream("auth0.properties"));	
+        } catch (IOException ex) {
             Logger.getLogger(AuthenticationApi.class.getName()).log(Level.SEVERE, null, ex);
         }
-        profileCache = CacheBuilder.newBuilder()
+    	
+    	profileCache = CacheBuilder.newBuilder()
                 .maximumSize(10000) // maximum 100 records can be cached
                 .expireAfterAccess(30, TimeUnit.MINUTES) // cache will expire after 30 minutes of access
                 .build(new CacheLoader<String, UserDTO>() { // build the cacheloader
@@ -87,7 +80,7 @@ public class AuthenticationApi {
                     }
                 });
     }
-
+        
     public HttpResponse<String> managementToken() throws UnirestException {
         Unirest.setTimeouts(0, 0);
        

--- a/auth0_utils/src/main/java/co/edu/uniandes/csw/auth/filter/FiltroAutenticacion.java
+++ b/auth0_utils/src/main/java/co/edu/uniandes/csw/auth/filter/FiltroAutenticacion.java
@@ -35,7 +35,6 @@ public class FiltroAutenticacion implements Filter {
     private AuthenticationApi auth;
     private Properties prop;
     private InputStream input;
-    private static final String FILE = System.getenv("AUTH0_PROPERTIES");
 
     @Override
     public void init(FilterConfig filterConfig) throws ServletException {
@@ -44,14 +43,17 @@ public class FiltroAutenticacion implements Filter {
 
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
-        try {
+        
+    	// load the configuration from an "auth0.properties" file in the classpath
+    	try {
             this.auth = new AuthenticationApi();
         } catch (UnirestException | JSONException | InterruptedException | ExecutionException ex) {
             Logger.getLogger(FiltroAutenticacion.class.getName()).log(Level.SEVERE, null, ex);
         }
-        prop = new Properties();
-        input = new FileInputStream(FILE);
-        prop.load(input);
+        
+    	// obtain the list of the other properties in the "auth0.properties" file
+        prop = this.auth.getProp();
+        
         HttpResponse<String> rp = null;
         String usuario = null, jwt = null, path = null, resource = null, subject = null;
         Jws<Claims> claim = null;


### PR DESCRIPTION
En lugar de usar una variable de entorno, esta versión usa el archivo "auth0.properties" en el classpath

Así, cualquier proyecto que use esta librería puede agregar su propio archivo "auth0.properties" en el "/src/main/resources" o "/src/test/resources".